### PR TITLE
Fixed a deadlock where a measurement requiring two queries would fail…

### DIFF
--- a/mr_freeze/devices/cryomagnetics_lm510.py
+++ b/mr_freeze/devices/cryomagnetics_lm510.py
@@ -140,18 +140,19 @@ class CryomagneticsLM510(AbstractCryomagneticsDevice):
             :rtype: str
             """
             self.instrument.channel_measurement_lock.acquire()
-            sleep(self.instrument.measurement_timeout)
 
-            self._prepare_measurement()
+            try:
+                sleep(self.instrument.measurement_timeout)
 
-            response = self.instrument.query(
-                "MEAS? %d" %
-                self.instrument.INDEX_TO_INSTRUMENT_CHANNELS[
-                    self.channel_number
-                ]
-            )
-
-            self.instrument.channel_measurement_lock.release()
+                self._prepare_measurement()
+                response = self.instrument.query(
+                    "MEAS? %d" %
+                    self.instrument.INDEX_TO_INSTRUMENT_CHANNELS[
+                        self.channel_number
+                    ]
+                )
+            finally:
+                self.instrument.channel_measurement_lock.release()
             return self.parse_response(response)
 
         @staticmethod


### PR DESCRIPTION
… to release the channel measurement lock if an exception was thrown.